### PR TITLE
Fixed truncated uptime in Node list table.

### DIFF
--- a/cesi/static/custom.js
+++ b/cesi/static/custom.js
@@ -979,7 +979,7 @@ var $selectnode = function(){
                     var $pid = result['process_info'][$counter]['pid'];
                     var $name = result['process_info'][$counter]['name'];
                     var $group = result['process_info'][$counter]['group'];
-                    var $uptime = result['process_info'][$counter]['description'].substring(17,24);
+                    var $uptime = result['process_info'][$counter]['description'].substring(result['process_info'][$counter]['description'].length - 8);
                     var $state = result['process_info'][$counter]['state'];
                     var $statename = result['process_info'][$counter]['statename'];
                     if($usertype == 0 || $usertype == 1){


### PR DESCRIPTION
Assuming the *uptime* in the description is always at the end of the string and using the `HH:mm:ss` format, use the last 8 characters from the description instead of a specific range - which may not line up if the previous content is longer/shorter than expected.