### PR TITLE
fix selector bug

### DIFF
--- a/cesi/static/custom.js
+++ b/cesi/static/custom.js
@@ -1066,7 +1066,7 @@ var $selectnode = function(){
 
                             if($dia.length==0){
                                 $logdiv.append('<div class="'+classname+'"></div>');
-                                $dia = $("."+classname);
+                                $dia = $("div[class='"+classname+"']");
                             }
                             $.ajax({
                                 url: url,

--- a/cesi/static/custom.js
+++ b/cesi/static/custom.js
@@ -535,7 +535,7 @@ var $selectgroupenv = function(){
                         var $uptime = result['process_list'][$counter][3];
                 
                         $table.append('<tr class="'+$nodename+'x'+$group_name+'x'+$name+'x'+$environment_name+'"></tr>');
-                        $tr = $('.'+$nodename+'x'+$group_name+'x'+$name+'x'+$environment_name);
+                        $tr = $('tr[class="'+$nodename+'x'+$group_name+'x'+$name+'x'+$environment_name+'"]');
             
                         if($usertype == 0 || $usertype == 1){ 
                             //check


### PR DESCRIPTION
If your job name has dots in name for instance "my_queue.username.my_queue_username_00" the log modal doesn't appear, because jquery can't recognize selector. This commit fix such problem