### PR TITLE
add support for process_name with '/'

### DIFF
--- a/cesi/web.py
+++ b/cesi/web.py
@@ -256,7 +256,7 @@ def showGroup(group_name, environment_name):
         return redirect(url_for('login'))
 
 
-@app.route('/node/<node_name>/process/<process_name>/restart')
+@app.route('/node/<node_name>/process/<path:process_name>/restart')
 def json_restart(node_name, process_name):
     if session.get('logged_in'):
         if session['usertype'] == 0 or session['usertype'] == 1:
@@ -283,7 +283,7 @@ def json_restart(node_name, process_name):
         return redirect(url_for('login'))
 
 # Process start
-@app.route('/node/<node_name>/process/<process_name>/start')
+@app.route('/node/<node_name>/process/<path:process_name>/start')
 def json_start(node_name, process_name):
     if session.get('logged_in'):
         if session['usertype'] == 0 or session['usertype'] == 1:
@@ -309,7 +309,7 @@ def json_start(node_name, process_name):
         return redirect(url_for('login'))
 
 # Process stop
-@app.route('/node/<node_name>/process/<process_name>/stop')
+@app.route('/node/<node_name>/process/<path:process_name>/stop')
 def json_stop(node_name, process_name):
     if session.get('logged_in'):
         if session['usertype'] == 0 or session['usertype'] == 1:
@@ -344,7 +344,7 @@ def getlist():
         return redirect(url_for('login'))
 
 # Show log for process
-@app.route('/node/<node_name>/process/<process_name>/readlog')
+@app.route('/node/<node_name>/process/<path:process_name>/readlog')
 def readlog(node_name, process_name):
     if session.get('logged_in'):
         if session['usertype'] == 0 or session['usertype'] == 1 or session['usertype'] == 2:


### PR DESCRIPTION
If a process name is defined in supervisor.conf like:
`process_name=Vacuum/sector1`
cesi is not able to start/stop/restart or readlog the process.

This PR fixes that