### PR TITLE
Allow running cesi with uWSGI (or any other WSGI server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ $ sudo systemctl daemon-reload
 $ sudo systemctl start cesi
 ```
 
+**Running Cesi with uWSGI**
+
+You may want to run Cesi using uWSGI (or any other WSGI deamon). Configure your system in the similiar way to running as a service and use `uwsgi` to start app. Check `defaults/cesi-uwsgi.ini` for details.
+
+While running with uWSGI Cesi config host and port are ignored.
+
+
 ## First Login
 
 Please change password after first login!

--- a/cesi/run.py
+++ b/cesi/run.py
@@ -16,16 +16,12 @@ app = Flask(
 app.config.from_object(__name__)
 app.secret_key = os.urandom(24)
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Cesi web server")
 
-    parser.add_argument("-c", "--config", type=str, help="config file", required=True)
-
-    args = parser.parse_args()
-    cesi = Cesi(config_file_path=args.config)
+def configure(config_file_path):
+    cesi = Cesi(config_file_path=config_file_path)
     activity = ActivityLog(log_path=cesi.activity_log)
 
-    from routes import *
+    import routes
 
     # or dynamic import
     from blueprints.nodes.routes import nodes
@@ -45,6 +41,18 @@ if __name__ == "__main__":
     app.register_blueprint(profile, url_prefix="/{}/profile".format(VERSION))
 
     signal.signal(signal.SIGHUP, lambda signum, frame: cesi.reload())
+
+    return cesi
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Cesi web server")
+
+    parser.add_argument("-c", "--config", type=str, help="config file", required=True)
+
+    args = parser.parse_args()
+
+    cesi = configure(args.config)
 
     app.run(
         host=cesi.host, port=cesi.port, use_reloader=cesi.auto_reload, debug=cesi.debug

--- a/cesi/wsgi.py
+++ b/cesi/wsgi.py
@@ -1,0 +1,4 @@
+import os
+from run import configure, app
+
+configure(os.environ['CESI_CONFIG_PATH'])

--- a/defaults/cesi-uwsgi.ini
+++ b/defaults/cesi-uwsgi.ini
@@ -1,0 +1,14 @@
+[uwsgi]
+# changed this to your cesi virtualenv
+virtualenv = /opt/cesi/.venv/
+# changed this to your cesi dir
+chdir = /opt/cesi/cesi/
+wsgi-file = wsgi.py
+callable = app
+# this address will be used instead of one from cesi.conf
+socket = 0.0.0.0:5000
+protocol = http
+master = true
+vacuum = true
+# store here path to cesi.conf file
+env = CESI_CONFIG_PATH=/etc/cesi.conf


### PR DESCRIPTION
`flask.run()` is starting a development server which may not be suitable to run cesi in production systems. In our envinorment we prefer to use uwsgi to host Flask apps.