### PR TITLE
Support URL path for supervisor nodes

### DIFF
--- a/cesi/core/xmlrpc.py
+++ b/cesi/core/xmlrpc.py
@@ -1,16 +1,19 @@
+from urllib.parse import urlparse, urlunparse
 import xmlrpc.client
 
 class XmlRpc:
     @staticmethod
     def connection(host, port, username, password):
-        server = "{}:{}".format(host, port)
+        if not host.startswith('http://') or host.startswith('https://'):
+            host = 'http://' + host
+        scheme, netloc, path, params, query, fragment = urlparse(host)
+        path = path.rstrip('/')
+        server = "{}:{}".format(netloc, port)
         credentials = "{}:{}".format(username, password)
         if username == "" and password == "":
-            uri = "http://{server}/RPC2".format(server=server)
+            uri = urlunparse((scheme, server, path + '/RPC2', params, query, fragment))
         else:
-            uri = "http://{credentials}@{server}/RPC2".format(
-                credentials=credentials, server=server
-            )
+            uri = urlunparse((scheme, '{credentials}@{server}'.format(credentials=credentials, server=server), path + '/RPC2', params, query, fragment))
 
         print(uri)
         return xmlrpc.client.ServerProxy(uri)


### PR DESCRIPTION
Support URL path for the node's host config, e.g.,

```toml
[[nodes]]
host = "example.com/supervisor/"
```