### PR TITLE
Support PUBLIC_URL for the api page

### DIFF
--- a/cesi/ui/src/services/api/index.js
+++ b/cesi/ui/src/services/api/index.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const API_PREFIX = "/api/v2";
+const API_PREFIX = process.env.PUBLIC_URL + "/api/v2";
 
 const getRequest = url => {
   return axios
@@ -201,7 +201,7 @@ const groups = {
 const version = {
   get: async () => {
     try {
-      const result = await getRequest("/api/version");
+      const result = await getRequest(process.env.PUBLIC_URL + "/api/version");
       console.log(result);
       return result.version;
     } catch (error) {


### PR DESCRIPTION
Support PUBLIC_URL for the api page, so that the cesi works when it is hosted under a subdirectory behind a reverse proxy. Setting `PUBLIC_URL` environment variable before `yarn build` will just work.