### PR TITLE
added Dockerfile and updated readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.7.2
+
+LABEL maintainer="whatever@whatever.com"
+
+# Enter version to install
+ENV CESI_VERSION 2.7.1
+ENV SETUP_PATH /var/opt/cesi
+ENV CESI_CONFIG_PATH /etc/cesi.conf.toml
+
+# Add cesi user/group to run gunicorn as non root
+RUN groupadd -r cesi && useradd -r -s /sbin/nologin -g cesi cesi
+
+WORKDIR ${SETUP_PATH}
+RUN wget --quiet --output-document cesi.tar.gz https://github.com/gamegos/cesi/releases/download/v${CESI_VERSION}/cesi-extended.tar.gz \
+    && tar -xzf cesi.tar.gz \
+    && rm cesi.tar.gz \
+    && chown -R cesi:cesi /var/opt/cesi
+
+WORKDIR ${SETUP_PATH}
+RUN apt-get update \
+    && pip3 install -r requirements.txt \
+    && pip3 install gunicorn
+
+COPY defaults/cesi.conf.toml ${CESI_CONFIG_PATH}
+
+WORKDIR ${SETUP_PATH}/cesi
+EXPOSE 5000
+USER cesi
+ENTRYPOINT [ "gunicorn", "-b", "0.0.0.0:5000", "--log-level", "info", "--reload", "wsgi:app" ]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Supervisor.
 
 - [Chef Cookbook][2]
 - [Package managers][3]
-- [Docker][4] (unavailable)
+- [Docker][4]
 - [Manuel Instructions](#manuel-instructions)
 
 ## Manuel Instructions
@@ -88,6 +88,21 @@ $ sudo systemctl start cesi
 You may want to run Cesi using uWSGI (or any other WSGI deamon). Configure your system in the similiar way to running as a service and use `uwsgi` to start app. Check `defaults/cesi-uwsgi.ini` for details.
 
 While running with uWSGI Cesi config host and port are ignored.
+
+**Run Cesi with Docker**
+
+```
+$ # Download the project (update version to fit your needs)
+$ wget --output-document cesi.tar.gz https://github.com/gamegos/cesi/releases/download/v2.7.1/cesi-extended.tar.gz
+$ tar -xzvf cesi.tar.gz
+$ cd cesi/
+$ docker build -t=cesi:2.7.1 .
+
+$ # Add --detach to background container
+$ docker run --publish 5000:5000 cesi:2.7.1
+
+$ # Open browser to http://localhost:5000 or http://127.0.0.1:5000
+```
 
 ## First Login
 


### PR DESCRIPTION
Added docker support via Dockerfile. Creates single Cesi container. Dockerfile can be used as example or to build local container for testing. 