### PR TITLE
Fix "ProtocolError" object attribute error

### DIFF
--- a/cesi/core/handlers.py
+++ b/cesi/core/handlers.py
@@ -10,7 +10,7 @@ def xmlrpc_exceptions(f):
         except xmlrpc.client.Fault as err:
             return False, err.faultString
         except xmlrpc.client.ProtocolError as err:
-            return False, err.faultString
+            return False, err.errmsg
         except Exception as err:
             return False, str(err)
 


### PR DESCRIPTION
## Bug description
- `xmlrpc.client.ProtocolError` does not have the `faultString` attribute.
- Sample error log:
    ```
    AttributeError: type object 'ProtocolError' has no attribute 'faultString'
    ```

## My solution
- The correct attribute of error message is `errmsg`, just simply replace it.
- Reference: [python3 doc - xmlrpc.client](https://docs.python.org/3/library/xmlrpc.client.html#xmlrpc.client.ProtocolError.errmsg)