### PR TITLE
`README.md`: Improve English

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Supervisor.
 - [Chef Cookbook][2]
 - [Package managers][3]
 - [Docker][4] (unavailable)
-- [Manuel Instructions](#manuel-instructions)
+- [Manual Installation](#manual-installation)
 
-## Manuel Instructions
+## Manual Installation
 
 **Install Dependencies For Cesi Api**
 


### PR DESCRIPTION
Because "Manuel Instructions" sounds funny :-)
Manual Instructions -- also doesn't make much sense

Correct to Manual Installation which is proper

See [manual](https://en.wiktionary.org/wiki/manual)